### PR TITLE
Add ADH partnership to facility websites

### DIFF
--- a/docs/resources/01-tools.md
+++ b/docs/resources/01-tools.md
@@ -18,5 +18,6 @@ request on GitHub!
 
 ## Facility websites
 * ZAB web services - https://github.com/zabartcc (Node.js)
+* ADH Partnership - https://github.com/adh-partnership (Go + Vue.js)
 * Control Center (training management system) - https://github.com/Vatsim-Scandinavia/controlcenter (PHP/Laravel)
 * CZQO website - https://github.com/czqoocavatsim/web (PHP/Laravel)


### PR DESCRIPTION
The ADH Partnership is a shared ARTCC code base containing the code for ZAN, HCF, ZDV and ZLCs web services.