### PR TITLE
Add link to django-allauth-vatsim OAuth2 provider

### DIFF
--- a/docs/resources/01-tools.md
+++ b/docs/resources/01-tools.md
@@ -12,6 +12,7 @@ request on GitHub!
 * [WordPress plugin](https://gitlab.com/jamiejanssen/wp-plugin-vatsim-connect-public)
 * [Moodle configuration](https://forums.vatsim.net/topic/29211-preview-vatsim-connect-for-moodle/)
 * VATSIM's Django apps use [Python Social Auth](https://python-social-auth.readthedocs.io/en/latest/)
+* [django-allauth OAuth2 provider](https://github.com/robin24/django-allauth-vatsim)
 
 ## Libraries
 * Vatsimphp - https://github.com/skymeyer/Vatsimphp (PHP)


### PR DESCRIPTION
Hey there!

I developed a VATSIM Connect OAuth2 provider for the popular django-allauth package, this PR adds a link to my GitHub repo to the docs.